### PR TITLE
Broken installation on non-Apple systems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ codecarbon==2.3.5
 fvcore==0.1.5.post20221221
 gpustat==1.1.1
 GPUtil==1.4.0
-lightning==2.2.2
+lightning==2.*
 nvitop==1.3.2
 psutil==5.9.8
 pyamdgpuinfo==2.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ codecarbon==2.3.5
 fvcore==0.1.5.post20221221
 gpustat==1.1.1
 GPUtil==1.4.0
-lightning==2.*
+lightning
 nvitop==1.3.2
 psutil==5.9.8
 pyamdgpuinfo==2.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ codecarbon==2.3.5
 fvcore==0.1.5.post20221221
 gpustat==1.1.1
 GPUtil==1.4.0
-lightning
+lightning==2.*
 nvitop==1.3.2
 psutil==5.9.8
 pyamdgpuinfo==2.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ nvitop==1.3.2
 psutil==5.9.8
 pyamdgpuinfo==2.1.6
 pytest==8.3.1
-setuptools==69.5.1
 torch==2.2.0
 torchvision==0.17.0
 tqdm==4.66.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-apple_gpu==0.3.0
 codecarbon==2.3.5
 fvcore==0.1.5.post20221221
 gpustat==1.1.1
@@ -10,6 +9,7 @@ pyamdgpuinfo==2.1.6
 pytest==8.3.1
 torch==2.2.0
 torchvision==0.17.0
+setuptools==69.5.1
 tqdm==4.66.2
 typing_extensions==4.12.2
 pipreqs

--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,10 @@ setup(
     version='1.0.0',
     packages=find_packages(),
     install_requires=required,  # Loaded from requirements.txt
+    extras_require={
+        'apple': [
+            # Optional dependencies for Apple/Mac
+            'apple_gpu==0.3.0'
+        ]
+    }
 )


### PR DESCRIPTION
`apple_gpu` dependency in requirements.txt causes the installation to fail on Linux systems.
Thus, I have moved it as optional dependency in the extras. Now, to install it you need to explicitly use:

```bash
pip install prov4ml[apple]

# Locally
pip install .[apple]
```

Whereas on Linux systems:

```bash
pip install prov4ml
```
