### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ GPUtil
 lightning
 netCDF4
 numpy
-nvitop
 pandas
 psutil
 pydot
@@ -14,3 +13,6 @@ torch
 torchvision
 tqdm
 typing_extensions
+prov
+pydot
+pipreqs


### PR DESCRIPTION
I had to add `prov` back to have the provenance logger working. I also added back pydot and pipreqs to be sure.
I removed nvtop as it can already be installed with the nvidia extra (`pip install prov4ml[nvidia]`) and if I well remember it causes problems on macOS.

Closes #4 